### PR TITLE
Validate Current Scene - New Key Map Proposal

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Editor/ZenMenuItems.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Editor/ZenMenuItems.cs
@@ -13,7 +13,7 @@ namespace Zenject
 {
     public static class ZenMenuItems
     {
-        [MenuItem("Edit/Zenject/Validate Current Scenes #%v")]
+        [MenuItem("Edit/Zenject/Validate Current Scenes #&v")]
         public static void ValidateCurrentScene()
         {
             ValidateCurrentSceneInternal();


### PR DESCRIPTION
As of 2017.2, Unity integrates the Vuforia Engine.
If you have the component installed it conflicts with Zenject's - Validate Current Scene - Hotkeys.
So my proposal is to change the old keys: Shift + Command/Windows + V.
With: Shift + Option/Alt + V.